### PR TITLE
 fix: showing if the var is false on first init

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This is an adaptation of the [Animate.css](https://daneden.github.io/animate.css/) animations using the @angular/animations library.
 
-[You can find a demo here.](https://stackblitz.com/edit/ngx-animations)
+[You can find a demo here.](https://stackblitz.com/edit/ngx-animations-directive-fix)
 
 ## Installing and importing NgxAnimations
 

--- a/libs/ngx-animations/src/lib/directives/if-animation.directive.ts
+++ b/libs/ngx-animations/src/lib/directives/if-animation.directive.ts
@@ -25,12 +25,12 @@ export class AnimIfDirective {
 
   @Input()
   set animIf(show: boolean) {
-    this.viewContainer.clear();
-    this.viewContainer.createEmbeddedView(this.templateRef);
     if (this.subscription) {
       this.subscription.unsubscribe();
     }
-    if (show) {
+    if (show && !this.shownBefore) {
+      this.viewContainer.clear();
+      this.viewContainer.createEmbeddedView(this.templateRef);
       const player = this.createPlayer(
         this.animIfInfo.startAnim,
         this.animIfInfo.time


### PR DESCRIPTION
Example if the variable set to false at first initialization.. the div supposed to vanish on inspect element at first load.. so it acts like a ngif. .. because the old one only triggering the vanishing if user change the variable to false on the fly.. regardless on the variable first initialization. 

#5 